### PR TITLE
connections.py: zip and telnet settings

### DIFF
--- a/app/connections.py
+++ b/app/connections.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
 #
 # The MIT License (MIT)
 #
@@ -477,9 +476,10 @@ def upload_data(*, settings, download_type=DownloadType.ALL, remove_unused=False
                     from zipfile import ZipFile
 
                     zip_file = f"{p_src}{os.sep}picons.zip"
-                    p_dst = "/media/hdd/"
-                    log("Compressing picons in one file...")
-                    with ZipFile(zip_file, "w", compresslevel=None) as zf:
+                    p_dst = os.path.abspath(os.path.join(p_dst, os.pardir))
+                    
+                    log("Compressing picons...")
+                    with ZipFile(zip_file, "w") as zf:
                         list(map(lambda p: zf.write(os.path.join(p_src, p), arcname=p), files_filter))
 
                     files_filter = {"picons.zip"}
@@ -489,9 +489,12 @@ def upload_data(*, settings, download_type=DownloadType.ALL, remove_unused=False
                 if compress:
                     if not tn:
                         callback("Telnet initialization ...")
-                        tn = telnet(host=host, user=settings.user, password=settings.password, timeout=10)
+                        tn = telnet(host=host,
+                                    user=settings.user,
+                                    password=settings.password,
+                                    timeout=settings.telnet_timeout)
                         next(tn)
-
+                        
                     cmd = f"unzip -q {p_dst}/picons.zip -d {settings.picons_path}"
                     callback("Extracting...")
                     tn.send(cmd)

--- a/app/connections.py
+++ b/app/connections.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # The MIT License (MIT)
 #
@@ -476,9 +477,9 @@ def upload_data(*, settings, download_type=DownloadType.ALL, remove_unused=False
                     from zipfile import ZipFile
 
                     zip_file = f"{p_src}{os.sep}picons.zip"
-                    p_dst = "/tmp"
-                    log("Compressing picons...")
-                    with ZipFile(zip_file, "w") as zf:
+                    p_dst = "/media/hdd/"
+                    log("Compressing picons in one file...")
+                    with ZipFile(zip_file, "w", compresslevel=None) as zf:
                         list(map(lambda p: zf.write(os.path.join(p_src, p), arcname=p), files_filter))
 
                     files_filter = {"picons.zip"}
@@ -488,7 +489,7 @@ def upload_data(*, settings, download_type=DownloadType.ALL, remove_unused=False
                 if compress:
                     if not tn:
                         callback("Telnet initialization ...")
-                        tn = telnet(host=host, user=settings.user, password=settings.password, timeout=2)
+                        tn = telnet(host=host, user=settings.user, password=settings.password, timeout=10)
                         next(tn)
 
                     cmd = f"unzip -q {p_dst}/picons.zip -d {settings.picons_path}"

--- a/app/connections.py
+++ b/app/connections.py
@@ -479,7 +479,7 @@ def upload_data(*, settings, download_type=DownloadType.ALL, remove_unused=False
                     p_dst = os.path.abspath(os.path.join(p_dst, os.pardir))
                     
                     log("Compressing picons...")
-                    with ZipFile(zip_file, "w") as zf:
+                    with ZipFile(zip_file, "w", compresslevel=None) as zf:
                         list(map(lambda p: zf.write(os.path.join(p_src, p), arcname=p), files_filter))
 
                     files_filter = {"picons.zip"}


### PR DESCRIPTION
I have tested many solutions, but this is the safest and faster (tested with a slow decoder and more than 10'000 picons)
I have removed compression from zip file because ratio compression of png picons is only 97% and of course no sense to compression.
With low telnet timeout (2-5) very often telnet stops and don't extract all picons.
picons.zip is stored now in /media/hdd/
Added changes to settings_dialog.glade