### PR TITLE
records vs recordings

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -95,7 +95,7 @@ class Defaults(Enum):
     STREAM_LIB = "mpv" if IS_WIN else "vlc"
     MAIN_LIST_PLAYBACK = False
     PROFILE_FOLDER_DEFAULT = False
-    RECORDS_PATH = f"{DATA_PATH}records{SEP}"
+    RECORDS_PATH = f"{DATA_PATH}recordings{SEP}"
     ACTIVATE_TRANSCODING = False
     ACTIVE_TRANSCODING_PRESET = f"720p TV{SEP}device"
 


### PR DESCRIPTION
Isn't it most appropriate "recordings" name path than "records", or like openATV "movie"?