### PR TITLE
[bug] Accept if lines in `lamedb` do not start with provider (`p:`)

### DIFF
--- a/app/eparser/enigma/lamedb.py
+++ b/app/eparser/enigma/lamedb.py
@@ -294,7 +294,7 @@ class LameDbReader:
             tmp.append(line)
             if i == size:
                 # check if provider (p:) is present in line
-                if not line.startswith("p:") and not ",p:" in line:
+                if "p:" not in line:
                     # To prevent cases of incorrect service data formation
                     # (e.g. the name contains a line break)
                     tmp.pop()

--- a/app/eparser/enigma/lamedb.py
+++ b/app/eparser/enigma/lamedb.py
@@ -293,7 +293,8 @@ class LameDbReader:
             i += 1
             tmp.append(line)
             if i == size:
-                if not line.startswith("p:"):
+                # check if provider (p:) is present in line
+                if not line.startswith("p:") and not ",p:" in line:
                     # To prevent cases of incorrect service data formation
                     # (e.g. the name contains a line break)
                     tmp.pop()


### PR DESCRIPTION
Accept if lines in `lamedb` do not start with provider (`p:`) but it comes later in the line (`,p:`)

Fixes #222 